### PR TITLE
fix condition pin is defined

### DIFF
--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -24,7 +24,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         self.bounce = int(self._settings.get(["bounce"]))
         self.switch = int(self._settings.get(["switch"]))
 
-        if self._settings.get(["pin"]) != -1:   # If a pin is defined
+        if self._settings.get(["pin"]) != "-1":   # If a pin is defined
             self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
             GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
 


### PR DESCRIPTION
added double quotes around the number, otherwise the condition is always true and it throws an exception on the octopi logs

before the change this was the error:

```
2017-05-07 13:40:34,681 - octoprint.plugins.filamentreload - INFO - Filament Sensor Reloaded started
2017-05-07 13:40:34,683 - octoprint.plugins.filamentreload - INFO - Filament Sensor active on GPIO Pin [-1]
2017-05-07 13:40:34,684 - octoprint.plugin - ERROR - Error while calling plugin filamentreload
Traceback (most recent call last):
  File "/home/pi/oprint/local/lib/python2.7/site-packages/OctoPrint-1.3.2-py2.7.egg/octoprint/plugin/__init__.py", line 229, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_filamentreload/__init__.py", line 29, in on_after_startup
    GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
ValueError: The channel sent is invalid on a Raspberry Pi
```

after the change, I just have the INFO log:

```
2017-05-07 13:49:52,647 - octoprint.plugins.filamentreload - INFO - Filament Sensor Reloaded started
```