### PR TITLE
Various fixes

### DIFF
--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -58,6 +58,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
             self._logger.info("Printing: Filament sensor enabled")
             if self.pin != -1:
                 GPIO.remove_event_detect(self.pin)
+                self.check_gpio(self.pin)
                 GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.check_gpio, bouncetime=self.bounce)
         # Not printing
         elif event in (
@@ -73,7 +74,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
             except Exception:
                 pass
 
-    def check_gpio(self, channel):
+    def check_gpio(self, _):
         sleep(self.bounce/1000)
         state = GPIO.input(self.pin)
         if state != self.switch:    # If the sensor is tripped

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -5,6 +5,7 @@ import octoprint.plugin
 from octoprint.events import eventManager, Events
 from flask import jsonify, make_response
 import RPi.GPIO as GPIO
+from time import sleep
 
 class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
                              octoprint.plugin.EventHandlerPlugin,
@@ -42,6 +43,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         if event == Events.PRINT_STARTED:  # If a new print is beginning
             self._logger.info("Printing started: Filament sensor enabled")
             if self.pin != -1:
+                GPIO.remove_event_detect(self.pin)
                 GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.check_gpio, bouncetime=self.bounce)
         elif event in (Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED):
             self._logger.info("Printing stopped: Filament sensor disabled")
@@ -51,6 +53,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
                 pass
 
     def check_gpio(self, channel):
+        sleep(self.bounce/1000)
         state = GPIO.input(self.pin)
         self._logger.debug("Detected sensor [%s] state [%s]"%(channel, state))
         if state != self.switch:    # If the sensor is tripped

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -67,7 +67,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
 
     @property
     def _filament_change(self):
-         return getattr(self, '_filament_change', False)
+        return self.__dict__.get('_filament_change', False)
 
     def on_event(self, event, payload):
         # Early abort in case of out ot filament when start printing, as we

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -36,6 +36,8 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         if self._settings.get(["pin"]) != "-1":   # If a pin is defined
             self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
             GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
+        else:
+            self._logger.info("Pin not configured, won't work unless configured!")
 
     def get_settings_defaults(self):
         return dict(
@@ -74,11 +76,14 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
     def check_gpio(self, channel):
         sleep(self.bounce/1000)
         state = GPIO.input(self.pin)
-        self._logger.debug("Detected sensor [%s] state [%s]"%(channel, state))
         if state != self.switch:    # If the sensor is tripped
-            self._logger.debug("Sensor [%s]"%state)
+            self._logger.info("Out of filament!")
             if self._printer.is_printing():
+                self._logger.info("Pausing print.")
                 self._printer.toggle_pause_print()
+        else:
+            self._logger.info("Filament detected!")
+
 
     def get_update_information(self):
         return dict(

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -48,13 +48,24 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         return [dict(type="settings", custom_bindings=False)]
 
     def on_event(self, event, payload):
-        if event == Events.PRINT_STARTED:  # If a new print is beginning
-            self._logger.info("Printing started: Filament sensor enabled")
+        # Printing
+        if event in (
+            Events.PRINT_STARTED,
+            Events.PRINT_RESUMED
+        ):
+            self._logger.info("Printing: Filament sensor enabled")
             if self.pin != -1:
                 GPIO.remove_event_detect(self.pin)
                 GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.check_gpio, bouncetime=self.bounce)
-        elif event in (Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED):
-            self._logger.info("Printing stopped: Filament sensor disabled")
+        # Not printing
+        elif event in (
+            Events.PRINT_DONE,
+            Events.PRINT_FAILED,
+            Events.PRINT_CANCELLED,
+            Events.PRINT_PAUSED,
+            Events.ERROR
+        ):
+            self._logger.info("Not printing: Filament sensor disabled")
             try:
                 GPIO.remove_event_detect(self.pin)
             except Exception:

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -36,12 +36,12 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         return str(self._settings.get(["after_pause_gcode"])).splitlines()
 
     @property
-    def filament_detected_gcode(self):
-        return str(self._settings.get(["filament_detected_gcode"])).splitlines()
+    def after_resume_gcode(self):
+        return str(self._settings.get(["after_resume_gcode"])).splitlines()
 
     def on_after_startup(self):
         self._logger.info("Filament Sensor Reloaded started")
-        if self._settings.get(["pin"]) != "-1":   # If a pin is defined
+        if self.sensor_enabled():
             self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
             GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
         else:
@@ -53,52 +53,67 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
             bounce  = 250,  # Debounce 250ms
             switch  = 0,    # Normally Open
             after_pause_gcode = '',
-            filament_detected_gcode = '',
+            after_resume_gcode = '',
         )
+
+    def sensor_enabled(self):
+        return self.pin != -1
+
+    def no_filament(self):
+        return GPIO.input(self.pin) != self.switch
 
     def get_template_configs(self):
         return [dict(type="settings", custom_bindings=False)]
 
+    @property
+    def _filament_change(self):
+         return getattr(self, '_filament_change', False)
+
     def on_event(self, event, payload):
-        # Printing
+        # Early abort in case of out ot filament when start printing, as we
+        # can't change with a cold nozzle
+        if event is Events.PRINT_STARTED and self.no_filament():
+            self._logger.info("Printing aborted: no filament detected!")
+            self._printer.cancel_print()
+        # Run after resume gcode
+        if event is Events.PRINT_RESUMED:
+            if self._filament_change:
+                self._logger.info("Sending after resume GCODE!")
+                self._printer.commands(self.after_resume_gcode)
+                self._filament_change = False
+        # Enable sensor
         if event in (
             Events.PRINT_STARTED,
             Events.PRINT_RESUMED
         ):
-            self._logger.info("Printing: Filament sensor enabled")
-            if self.pin != -1:
+            self._logger.info("%s: Enabling filament sensor." % (event))
+            if self.sensor_enabled():
                 GPIO.remove_event_detect(self.pin)
-                self.check_gpio(self.pin)
-                GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.check_gpio, bouncetime=self.bounce)
-        # Not printing
+                GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.sensor_callback, bouncetime=self.bounce)
+        # Disable sensor
         elif event in (
             Events.PRINT_DONE,
             Events.PRINT_FAILED,
             Events.PRINT_CANCELLED,
             Events.ERROR
         ):
-            self._logger.info("Not printing: Filament sensor disabled")
-            try:
-                GPIO.remove_event_detect(self.pin)
-            except Exception:
-                pass
+            self._logger.info("%s: Disabling filament sensor." % (event))
+            GPIO.remove_event_detect(self.pin)
 
-    def check_gpio(self, _):
+    def sensor_callback(self, _):
         sleep(self.bounce/1000)
-        state = GPIO.input(self.pin)
-        if state != self.switch:
-            self._logger.info("Out of filament, pausing!")
-            self._printer.pause_print()
-            if self.after_pause_gcode:
-                self._logger.info("Sending after pause GCODE")
-                self._printer.commands(self.after_pause_gcode)
-            self._filament_change = True
+        if self.no_filament():
+            if self._filament_change:
+                self._logger.info("Out of filament, waiting for replacement!")
+            else:
+                self._logger.info("Out of filament, pausing!")
+                self._printer.pause_print()
+                if self.after_pause_gcode:
+                    self._logger.info("Sending after pause GCODE")
+                    self._printer.commands(self.after_pause_gcode)
+                self._filament_change = True
         else:
-            self._logger.info("Filament detected!")
-            if getattr(self, '_filament_change', False):
-                self._logger.info("Sending filament detected GCODE!")
-                self._printer.commands(self.filament_detected_gcode)
-                self._filament_change = False
+            self._logger.info("Filament detected, resume to continue!")
 
     def get_update_information(self):
         return dict(

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -19,12 +19,20 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         GPIO.setmode(GPIO.BOARD)       # Use the board numbering scheme
         GPIO.setwarnings(False)        # Disable GPIO warnings
 
+    @property
+    def pin(self):
+        return int(self._settings.get(["pin"]))
+
+    @property
+    def bounce(self):
+        return int(self._settings.get(["bounce"]))
+
+    @property
+    def switch(self):
+        return int(self._settings.get(["switch"]))
+
     def on_after_startup(self):
         self._logger.info("Filament Sensor Reloaded started")
-        self.pin = int(self._settings.get(["pin"]))
-        self.bounce = int(self._settings.get(["bounce"]))
-        self.switch = int(self._settings.get(["switch"]))
-
         if self._settings.get(["pin"]) != "-1":   # If a pin is defined
             self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
             GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT

--- a/octoprint_filamentreload/templates/filamentreload_settings.jinja2
+++ b/octoprint_filamentreload/templates/filamentreload_settings.jinja2
@@ -24,4 +24,16 @@ Define the pin used by your sensor and the debounce timing for false positive pr
             </select>
         </div>
     </div>
+    <div class="control-group">
+        <label class="control-label">{{ _('After pause GCODE:') }}</label>
+        <div class="controls">
+            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.after_pause_gcode"></textarea>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">{{ _('Filament detected GCODE:') }}</label>
+        <div class="controls">
+            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.filament_detected_gcode"></textarea>
+        </div>
+    </div>
 </form>

--- a/octoprint_filamentreload/templates/filamentreload_settings.jinja2
+++ b/octoprint_filamentreload/templates/filamentreload_settings.jinja2
@@ -31,9 +31,9 @@ Define the pin used by your sensor and the debounce timing for false positive pr
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label">{{ _('Filament detected GCODE:') }}</label>
+        <label class="control-label">{{ _('After resume GCODE:') }}</label>
         <div class="controls">
-            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.filament_detected_gcode"></textarea>
+            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.after_resume_gcode"></textarea>
         </div>
     </div>
 </form>


### PR DESCRIPTION
Hello,

This pull request should fix several bugs I found:

# Error accessing attribute:

```
File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_filamentreload/__init__.py", line 45, in on_event
  if self.pin != -1:
AttributeError: 'FilamentReloadedPlugin' object has no attribute 'pin'
```
This happens because there's no guarantee attributes will be set when accessed. I extracted them as properties so they'll always work.

# Better logging

It was a pain to debug due to insuficcient logging.

# Better dealing of printing/not printing events

Now the sensor is disabled while paused.

# Fix unstable sensor signal

I am using a mechanical sensor, and it bounces a lot. The bouncetime argument of add_event_detect does not fix it, as it is basically a limiter to how ofter the callback should be called. When the sensor triggers, it is still bouncing and GPIO.input(self.pin) can read a wrong value while the value is changing. Adding a sleep fixes this

# Fix double add_event_detect

```
File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_filamentreload/__init__.py", line 45, in on_event
  GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.check_gpio, bouncetime=self.bounce)
RuntimeError: Conflicting edge detection already enabled for this GPIO channel
```

I found cases where this was happening. Adding GPIO.remove_event_detect(self.pin) before registering a new callback is always benign and solves this case.

# Fix start printing without filament

Added self.check_gpio(self.pin) when enabling the sensor, so that filament missing can be caught as soon as printing starts (not just when its state changes).