### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # OctoPrint-FilamentReloaded
 
-Based on the Octoprint-Filament plugin by MoonshineSG (https://github.com/MoonshineSG/Octoprint-Filament), this modification adds the ability to modify your configuration through OctoPrint settings, as well as adding configurations for both NO and NC switches.
+[OctoPrint](http://octoprint.org/) plugin that integrates with a filament sensor hooked up to a Raspberry Pi GPIO pin and allows the filament spool to be changed during a print if the filament runs out.
 
-Future developments are planned to include multiple filament sensors, pop-ups, pre-print validation and custom filament run-out scripting.
+Future developments are planned to include multiple filament sensors and pop-ups.
 
-## Setup
+Initial work based on the [Octoprint-Filament](https://github.com/MoonshineSG/Octoprint-Filament) plugin by MoonshineSG.
 
-Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
-or manually using this URL:
-
-    https://github.com/kontakt/Octoprint-Filament-Reloaded/archive/master.zip
+## Required sensor
 
 Using this plugin requires a filament sensor. The code is set to use the Raspberry Pi's internal Pull-Up resistors, so the switch should be between your detection pin and a ground pin.
 
 This plugin is using the GPIO.BOARD numbering scheme, the pin being used needs to be selected by the physical pin number.
+
+## Features
+
+* Configurable GPIO pin.
+* Debounce noisy sensors.
+* Support norbally open and normally closed sensors.
+* Execution of custom GCODE when out of filament detected.
+* Optionally pause print when out of filament.
+
+## Installation
+
+* Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager).
+* Manually using this URL: https://github.com/kontakt/Octoprint-Filament-Reloaded/archive/master.zip
+
+## Configuration
+
+After installation, configure the plugin via OctoPrint Settings interface.

--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -2,10 +2,10 @@
 from __future__ import absolute_import
 
 import octoprint.plugin
-from octoprint.events import eventManager, Events
-from flask import jsonify, make_response
+from octoprint.events import Events
 import RPi.GPIO as GPIO
 from time import sleep
+
 
 class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
                              octoprint.plugin.EventHandlerPlugin,
@@ -16,7 +16,6 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         self._logger.info("Running RPi.GPIO version '{0}'".format(GPIO.VERSION))
         if GPIO.VERSION < "0.6":       # Need at least 0.6 for edge detection
             raise Exception("RPi.GPIO must be greater than 0.6")
-        GPIO.setmode(GPIO.BOARD)       # Use the board numbering scheme
         GPIO.setwarnings(False)        # Disable GPIO warnings
 
     @property
@@ -36,47 +35,44 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         return int(self._settings.get(["mode"]))
 
     @property
-    def after_pause_gcode(self):
-        return str(self._settings.get(["after_pause_gcode"])).splitlines()
+    def no_filament_gcode(self):
+        return str(self._settings.get(["no_filament_gcode"])).splitlines()
 
     @property
-    def after_resume_gcode(self):
-        return str(self._settings.get(["after_resume_gcode"])).splitlines()
+    def pause_print(self):
+        return self._settings.get_boolean(["pause_print"])
+
+    def _setup_sensor(self):
+        if self.sensor_enabled():
+            self._logger.info("Setting up sensor.")
+            if self.mode == 0:
+                self._logger.info("Using Board Mode")
+                GPIO.setmode(GPIO.BOARD)
+            else:
+                self._logger.info("Using BCM Mode")
+                GPIO.setmode(GPIO.BCM)
+            self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
+            GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        else:
+            self._logger.info("Pin not configured, won't work unless configured!")
 
     def on_after_startup(self):
         self._logger.info("Filament Sensor Reloaded started")
-        if self.mode == 0:
-             GPIO.setmode(GPIO.BOARD)
-        else:
-             GPIO.setmode(GPIO.BCM)
-        if self.sensor_enabled():
-            self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
-            GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
-        else:
-            self._logger.info("Pin not configured, won't work unless configured!")
+        self._setup_sensor()
 
     def get_settings_defaults(self):
         return dict(
             pin     = -1,   # Default is no pin
             bounce  = 250,  # Debounce 250ms
             switch  = 0,    # Normally Open
-            mode    = 0     # Board Mode
-            after_pause_gcode = '',
-            after_resume_gcode = '',
+            mode    = 0,    # Board Mode
+            no_filament_gcode = '',
+            pause_print = True,
         )
 
     def on_settings_save(self, data):
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
-
-        if self.mode == 0:
-            GPIO.setmode(GPIO.BOARD)
-        else:
-            GPIO.setmode(GPIO.BCM)
-
-        if self._settings.get(["pin"]) != "-1":   # If a pin is defined
-            self._logger.info("Filament Sensor active on GPIO Pin [%s]"%self.pin)
-            GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # Initialize GPIO as INPUT
-
+        self._setup_sensor()
 
     def sensor_enabled(self):
         return self.pin != -1
@@ -87,22 +83,12 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
     def get_template_configs(self):
         return [dict(type="settings", custom_bindings=False)]
 
-    @property
-    def _filament_change(self):
-        return self.__dict__.get('_filament_change', False)
-
     def on_event(self, event, payload):
         # Early abort in case of out ot filament when start printing, as we
         # can't change with a cold nozzle
         if event is Events.PRINT_STARTED and self.no_filament():
             self._logger.info("Printing aborted: no filament detected!")
             self._printer.cancel_print()
-        # Run after resume gcode
-        if event is Events.PRINT_RESUMED:
-            if self._filament_change:
-                self._logger.info("Sending after resume GCODE!")
-                self._printer.commands(self.after_resume_gcode)
-                self._filament_change = False
         # Enable sensor
         if event in (
             Events.PRINT_STARTED,
@@ -111,7 +97,11 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
             self._logger.info("%s: Enabling filament sensor." % (event))
             if self.sensor_enabled():
                 GPIO.remove_event_detect(self.pin)
-                GPIO.add_event_detect(self.pin, GPIO.BOTH, callback=self.sensor_callback, bouncetime=self.bounce)
+                GPIO.add_event_detect(
+                    self.pin, GPIO.BOTH,
+                    callback=self.sensor_callback,
+                    bouncetime=self.bounce
+                )
         # Disable sensor
         elif event in (
             Events.PRINT_DONE,
@@ -125,17 +115,15 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
     def sensor_callback(self, _):
         sleep(self.bounce/1000)
         if self.no_filament():
-            if self._filament_change:
-                self._logger.info("Out of filament, waiting for replacement!")
-            else:
-                self._logger.info("Out of filament, pausing!")
+            self._logger.info("Out of filament!")
+            if self.pause_print:
+                self._logger.info("Pausing print.")
                 self._printer.pause_print()
-                if self.after_pause_gcode:
-                    self._logger.info("Sending after pause GCODE")
-                    self._printer.commands(self.after_pause_gcode)
-                self._filament_change = True
+            if self.no_filament_gcode:
+                self._logger.info("Sending out of filament GCODE")
+                self._printer.commands(self.no_filament_gcode)
         else:
-            self._logger.info("Filament detected, resume to continue!")
+            self._logger.info("Filament detected!")
 
     def get_update_information(self):
         return dict(

--- a/octoprint_filamentreload/templates/filamentreload_settings.jinja2
+++ b/octoprint_filamentreload/templates/filamentreload_settings.jinja2
@@ -1,23 +1,21 @@
-<h4>{{ _('Filament Sensor') }}</h4>
-Define the pin used by your sensor and the debounce timing for false positive prevention.
-<br>
+<h4>{{ _('Filament Sensor Reloaded') }}</h4>
 <form class="form-horizontal">
     <div class="control-group">
         <label class="control-label">{{ _('Pin:') }}</label>
-        <div class="controls" data-toggle="tooltip" title="{{ _('Which GPIO pin your switch is attached to') }}">
+        <div class="controls" data-toggle="tooltip" title="{{ _('Which Raspberry Pi GPIO pin your switch is attached to (-1 disables the plugin)') }}">
             <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.filamentreload.pin">
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">{{ _('Debounce Time:') }}</label>
-        <div class="controls" data-toggle="tooltip" title="{{ _('The amount of time a signal needs to stay constant to be considered valid') }}">
+        <div class="controls" data-toggle="tooltip" title="{{ _('When a sensor state change happens, wait for this amount of time to wait for the signal to stabilize.') }}">
             <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.filamentreload.bounce">
             <span class="add-on">ms</span>
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">{{ _('Switch Type:') }}</label>
-        <div class="controls" data-toggle="tooltip" title="{{ _('Whether the sensor should trip when the switch goes HIGH or LOW, Normally Open is LOW when filament is present, and Normally Closed is HIGH when filament is present') }}">
+        <div class="controls" data-toggle="tooltip" title="{{ _('Whether the sensor should trip when the switch goes HIGH or LOW, Normally Open is LOW when filament is present, and Normally Closed is HIGH when filament is present.') }}">
             <select class="select-mini" data-bind="value: settings.plugins.filamentreload.switch">
                 <option value=0>{{ _('Normally Open') }}</option>
                 <option value=1>{{ _('Normally Closed') }}</option>
@@ -34,15 +32,16 @@ Define the pin used by your sensor and the debounce timing for false positive pr
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label">{{ _('After pause GCODE:') }}</label>
+        <label class="control-label">{{ _('Out of filament GCODE:') }}</label>
         <div class="controls">
-            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.after_pause_gcode"></textarea>
+            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.no_filament_gcode"></textarea>
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label">{{ _('After resume GCODE:') }}</label>
-        <div class="controls">
-            <textarea rows="4" class="block" data-bind="value: settings.plugins.filamentreload.after_resume_gcode"></textarea>
+        <div class="controls" data-toggle="tooltip" title="{{ _('Beware that for some printers, pausing is incompatible with M600 (Filament change pause) as both will move the print head and it can resume at a different position as it paused.') }}">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.filamentreload.pause_print"> {{ _('Pause print when out of filament') }}
+            </label>
         </div>
     </div>
 </form>


### PR DESCRIPTION
I did several scattered changes in the code:

- Remove unused imports.
- Remove wrong sensor setup at initialize().
- Deprecate after pasue/resume gcode: single gcode execution now.
- Update settings template:
  - Remove obsolete messag.
  - Better tool tips.
  - New options.
- Update README.md

The most notable changes are that pausing is now optional and I deprecated after pause/resume gcodes. I spent some time testing with my Prusa i3 MK2 and pause + M600 does not work. Octoprint's hard coded to pause in a way that it moves the print head. If M600 is given when paused, it will resume printing at the wrong Z height. I tried several different combinations, no luck. I figured changing filaments would go either for "full manual", with pause and no gcode, OR just via the gcode. So I added both cases to the settings, and simplified it a bit.

I did a print test here with it, it seems to be working reliably without pause and M600 gcode.