### PR TITLE
added feature for sending GCODE only once.

### DIFF
--- a/octoprint_filamentreload/__init__.py
+++ b/octoprint_filamentreload/__init__.py
@@ -42,6 +42,10 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
     def pause_print(self):
         return self._settings.get_boolean(["pause_print"])
 
+    @property
+    def send_gcode_only_once(self):
+        return self._settings.get_boolean(["send_gcode_only_once"])
+
     def _setup_sensor(self):
         if self.sensor_enabled():
             self._logger.info("Setting up sensor.")
@@ -68,6 +72,7 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
             mode    = 0,    # Board Mode
             no_filament_gcode = '',
             pause_print = True,
+            send_gcode_only_once = False, # Default set to False for backward compatibility
         )
 
     def on_settings_save(self, data):
@@ -116,6 +121,9 @@ class FilamentReloadedPlugin(octoprint.plugin.StartupPlugin,
         sleep(self.bounce/1000)
         if self.no_filament():
             self._logger.info("Out of filament!")
+            if self.send_gcode_only_once:
+                self._logger.info("Sending GCODE only once...removing filament sensor callback.")
+                GPIO.remove_event_detect(self.pin)
             if self.pause_print:
                 self._logger.info("Pausing print.")
                 self._printer.pause_print()

--- a/octoprint_filamentreload/templates/filamentreload_settings.jinja2
+++ b/octoprint_filamentreload/templates/filamentreload_settings.jinja2
@@ -44,4 +44,12 @@
             </label>
         </div>
     </div>
+    <div class="control-group">
+        <div class="controls" data-toggle="tooltip" title="{{ _('With this option checked, the plugin will ignore subsequent reports of out of filament until the print is resumed again.') }}">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.filamentreload.send_gcode_only_once"> {{ _('Send GCODE only once when out of filament.') }}
+            </label>
+        </div>
+    </div>
+
 </form>


### PR DESCRIPTION
Made some changes to address an issue that has been reported a few times here. I picked one of the issues (issue 22) as the name of the branch. This has been referred to as a "looping" problem in other posts. It basically allows the user to configure witch a checkbox if they want to old classic behaviour of resending the GCODE or if they want to send it only once. The way this is accomplished is by simply unhooking the callback when the filament is out and then rehooking it again when they resume. 